### PR TITLE
Correct resource path for views

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This package is based heavily on [this article](https://medium.com/nicooprat/acf
 ## Installation
 Run the following in your Sage (v9 or 10) based theme directory:
 ```sh
-composer require "larodiel/sage-acf-gutenberg-blocks"
+composer require "abbo-man/sage-acf-gutenberg-blocks"
 ```
 
 ## Creating blocks

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
-  "name": "larodiel/sage-acf-gutenberg-blocks",
+  "name": "abbo-man/sage-acf-gutenberg-blocks",
   "description": "Fork of the original Sage ACF Gutenberg Blocks project. Create Gutenberg blocks from Sage blade templates and ACF fields.",
   "keywords": [
     "wordpress",
     "gutenberg",
     "advanced custom fields"
   ],
-  "homepage": "https://github.com/larodiel/sage-acf-wp-blocks",
+  "homepage": "https://github.com/abbo-man/sage-acf-wp-blocks",
   "license": "MIT",
   "authors": [
     {
@@ -24,6 +24,12 @@
       "name": "Victor Larodiel",
       "email": "victor@larodiel.com",
       "homepage": "https://github.com/larodiel",
+      "role": "Developer"
+    },
+    {
+      "name": "Thomas Abbondi",
+      "email": "thomas.abbondi@opiquad.it",
+      "homepage": "https://github.com/abbo-man",
       "role": "Developer"
     }
   ],

--- a/composer.lock
+++ b/composer.lock
@@ -1,19 +1,20 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "718df4665b1c462a01f495c630c5608f",
+    "content-hash": "6da17fde01e1db9edcb9d8bea18a680c",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.2"
+        "php": ">=7.4"
     },
-    "platform-dev": []
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
 }

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -256,7 +256,7 @@ function checkAssetPath(&$path, $block)
     if (isSage10()) {
         $useVite = class_exists('\Illuminate\Support\Facades\Vite');
 
-        if (!$useVite) {
+        if ($useVite) {
             $path = \Illuminate\Support\Facades\Vite::asset($path);
             return;
         } elseif (function_exists('\Roots\bundle')) {

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -167,8 +167,6 @@ add_action('acf/init', function () {
                     }, explode(' ', $file_headers['parent']));
                 }
 
-                dump($data);
-
                 // Register the block with ACF
                 \acf_register_block_type(apply_filters("sage/blocks/$slug/register-data", $data));
             }

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -167,6 +167,8 @@ add_action('acf/init', function () {
                     }, explode(' ', $file_headers['parent']));
                 }
 
+                dump($data);
+
                 // Register the block with ACF
                 \acf_register_block_type(apply_filters("sage/blocks/$slug/register-data", $data));
             }
@@ -256,28 +258,16 @@ function checkAssetPath(&$path, $block)
     if (isSage10()) {
         $useVite = class_exists('\Illuminate\Support\Facades\Vite');
 
-        if ($useVite || function_exists('\Roots\bundle')) {
-            $insertBlocks = function () use ($block, $path, $useVite) {
+        if (!$useVite) {
+            $path = \Illuminate\Support\Facades\Vite::asset($path);
+            return;
+        } elseif (function_exists('\Roots\bundle')) {
+            $insertBlocks = function () use ($block, $path) {
                 if (!has_block("acf/$block")) {
                     return;
                 }
 
-                if (!$useVite) {
-                    \Roots\bundle($path)->enqueue();
-                    return;
-                }
-
-                $style = \Illuminate\Support\Facades\Vite::asset($path);
-
-                switch (pathinfo($style, PATHINFO_EXTENSION)) {
-                    case 'css':
-                        wp_enqueue_style($path, $style);
-                        break;
-                    case 'js':
-                    case 'mjs':
-                        wp_enqueue_script($path, $style);
-                        break;
-                }
+                \Roots\bundle($path)->enqueue();
             };
 
             add_action('wp_enqueue_scripts', $insertBlocks, 50);

--- a/sage-acf-gutenberg-blocks.php
+++ b/sage-acf-gutenberg-blocks.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace App;
+
 define('SAGE_ACF_GUTENBERG_BLOCKS_VERSION', '0.8.1');
 
 // Check whether WordPress and ACF are available; bail if not.
@@ -103,7 +104,7 @@ add_action('acf/init', function () {
                     'keywords' => explode(' ', $file_headers['keywords']),
                     'mode' => $file_headers['mode'],
                     'align' => $file_headers['align'],
-                    'render_callback'  => __NAMESPACE__.'\\sage_blocks_callback',
+                    'render_callback'  => __NAMESPACE__ . '\\sage_blocks_callback',
                     'enqueue_style'   => $file_headers['enqueue_style'],
                     'enqueue_script'  => $file_headers['enqueue_script'],
                     'enqueue_assets'  => $file_headers['enqueue_assets'],
@@ -161,7 +162,7 @@ add_action('acf/init', function () {
 
                 // If the Parent header is set in the template, restrict this block to specific parent blocks
                 if (!empty($file_headers['parent'])) {
-                    $data['parent'] = array_map(function($name) {
+                    $data['parent'] = array_map(function ($name) {
                         return validateBlockName($name);
                     }, explode(' ', $file_headers['parent']));
                 }
@@ -193,7 +194,7 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
         $slug,
         $block['className'],
         $block['is_preview'] ? 'is-preview' : null,
-        'align'.$block['align']
+        'align' . $block['align']
     ];
 
     // Filter the block data.
@@ -206,10 +207,17 @@ function sage_blocks_callback($block, $content = '', $is_preview = false, $post_
     $directories = apply_filters('sage-acf-gutenberg-blocks-templates', []);
 
     foreach ($directories as $directory) {
-        $view = ltrim($directory, 'views/') . '/' . $slug;
-        $templatePath = get_stylesheet_directory() . "/$directory/$slug";
+        $dir = isSage10() ? \Roots\resource_path($directory) : \locate_template($directory);
 
-        if(!file_exists($templatePath.'.blade.php')){
+        // Sanity check whether the directory we're iterating over exists first
+        if (!file_exists($dir)) {
+            continue;
+        }
+
+        $view = ltrim($directory, 'views/') . '/' . $slug;
+        $templatePath = "{$dir}/{$slug}";
+
+        if (!file_exists($templatePath . '.blade.php')) {
             continue;
         }
 
@@ -271,7 +279,8 @@ function checkAssetPath(&$path, $block)
  *
  * @return void|string
  */
-function validateBlockName($name) {
+function validateBlockName($name)
+{
     global $sage_error;
 
     // A block name can only contain lowercase alphanumeric characters and dashes, and must begin with a letter.


### PR DESCRIPTION
The `sage_blocks_callback` use a different method to get the path for views.
Using the same approach of `acf/init` to get directory resolve the missing block rendering.